### PR TITLE
Cleanup logging in tests

### DIFF
--- a/main/test/Main.spec.js
+++ b/main/test/Main.spec.js
@@ -19,10 +19,6 @@ describe("unit test for Main", function () {
         return main.getRelevantSongsTestingPurposes()
             .then((resp) => {
                 assertResponseFromMain(resp);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -33,7 +29,6 @@ describe("unit test for Main", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidDataURLError);
             });
     });
@@ -43,10 +38,6 @@ describe("unit test for Main", function () {
         return main.getRelevantSongs()
             .then((resp) => {
                 assertResponseFromMain(resp);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -56,7 +47,6 @@ describe("unit test for Main", function () {
                 chai.assert.fail("expected error to be thrown");
             })
             .catch((e) => {
-                console.log(e);
                 chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -67,7 +57,6 @@ describe("unit test for Main", function () {
                 chai.assert.fail("expected error to be thrown");
             })
             .catch((e) => {
-                console.log(e);
                 chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -78,7 +67,6 @@ describe("unit test for Main", function () {
                 chai.assert.fail("expected error to be thrown");
             })
             .catch((e) => {
-                console.log(e);
                 chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -89,7 +77,6 @@ describe("unit test for Main", function () {
                 chai.assert.fail("expected error to be thrown");
             })
             .catch((e) => {
-                console.log(e);
                 chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
             });
     });

--- a/main/test/clustering/KMean.spec.js
+++ b/main/test/clustering/KMean.spec.js
@@ -19,35 +19,25 @@ describe("unit test for KMeans", function () {
     });
 
     it("test K Means and single silhouette", function () {
-        try {
-            const k = 8;
-            const clusters = kMean.kMean(songs, k);
-            chai.expect(clusters.length).to.be.equal(k);
-            const silhouetteValue = kMean.computeSilhouetteValue(clusters);
-            console.log("SILHOUETTE VALUE - " + silhouetteValue);
-            chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
-        } catch (err) {
-            console.log(err);
-            chai.expect.fail("not supposed to fail");
-        }
+        const k = 8;
+        const clusters = kMean.kMean(songs, k);
+        chai.expect(clusters.length).to.be.equal(k);
+        const silhouetteValue = kMean.computeSilhouetteValue(clusters);
+        console.log("SILHOUETTE VALUE - " + silhouetteValue);
+        chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
     });
 
 
     it("find optimum silhouette value", function () {
-        try {
-            const kStart = 4;
-            const kEnd = 20;
-            const arr = new Map();
-            for (let k = kStart; k <= kEnd; k++) {
-                const clusters = kMean.kMean(songs, k);
-                chai.expect(clusters.length).to.be.equal(k);
-                const silhouetteValue = kMean.computeSilhouetteValue(clusters);
-                chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
-                arr.set(k + " = " + silhouetteValue, clusters);
-            }
-        } catch (err) {
-            console.log(err);
-            chai.expect.fail("not supposed to fail");
+        const kStart = 4;
+        const kEnd = 20;
+        const arr = new Map();
+        for (let k = kStart; k <= kEnd; k++) {
+            const clusters = kMean.kMean(songs, k);
+            chai.expect(clusters.length).to.be.equal(k);
+            const silhouetteValue = kMean.computeSilhouetteValue(clusters);
+            chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
+            arr.set(k + " = " + silhouetteValue, clusters);
         }
     });
 
@@ -57,8 +47,8 @@ describe("unit test for KMeans", function () {
             kMean.k = 2;
             kMean.features = ["danceability", "energy", "acousticness", "tempo", "valence"];
             kMean.iterate();
+            chai.expect.fail("Should have failed");
         } catch (err) {
-            console.log(err);
             chai.expect(err).to.be.instanceOf(Err.KMeanClusterError);
         }
     });
@@ -71,57 +61,42 @@ describe("unit test for KMeans", function () {
             kMean.MAX_ITERATIONS = 30;
             kMean.iterations = kMean.MAX_ITERATIONS + 1;
             kMean.iterate();
+            chai.expect.fail("Should have failed");
         } catch (err) {
-            console.log(err);
             chai.expect(err).to.be.instanceOf(Err.KMeanIterationError);
         }
     });
 
     it("find optimum silhouette value with clear clustered data", function () {
-        try {
-            const kStart = 2;
-            const kEnd = 4;
-            const arr = new Map();
-            for (let k = kStart; k <= kEnd; k++) {
-                const clusters = kMean.kMean(songsClearCluster, k);
-                chai.expect(clusters.length).to.be.equal(k);
-                const silhouetteValue = kMean.computeSilhouetteValue(clusters);
-                chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
-                arr.set(k + " = " + silhouetteValue, clusters);
-            }
-        } catch (err) {
-            console.log(err);
-            chai.expect.fail("not supposed to fail");
+        const kStart = 2;
+        const kEnd = 4;
+        const arr = new Map();
+        for (let k = kStart; k <= kEnd; k++) {
+            const clusters = kMean.kMean(songsClearCluster, k);
+            chai.expect(clusters.length).to.be.equal(k);
+            const silhouetteValue = kMean.computeSilhouetteValue(clusters);
+            chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
+            arr.set(k + " = " + silhouetteValue, clusters);
         }
     });
 
     it("find optimum silhouette value with larger clear clustered data", function () {
-        try {
-            const kStart = 2;
-            const kEnd = 8;
-            const arr = new Map();
-            for (let k = kStart; k <= kEnd; k++) {
-                const clusters = kMean.kMean(songsLargeClearCluster, k);
-                chai.expect(clusters.length).to.be.equal(k);
-                const silhouetteValue = kMean.computeSilhouetteValue(clusters);
-                chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
-                arr.set(k + " = " + silhouetteValue, clusters);
-            }
-        } catch (err) {
-            console.log(err);
-            chai.expect.fail("not supposed to fail");
+        const kStart = 2;
+        const kEnd = 8;
+        const arr = new Map();
+        for (let k = kStart; k <= kEnd; k++) {
+            const clusters = kMean.kMean(songsLargeClearCluster, k);
+            chai.expect(clusters.length).to.be.equal(k);
+            const silhouetteValue = kMean.computeSilhouetteValue(clusters);
+            chai.assert(silhouetteValue <= 1 && silhouetteValue >= -1);
+            arr.set(k + " = " + silhouetteValue, clusters);
         }
     });
 
     it("test getOptimalKClusters", function () {
-        try {
-            const [bestK, clusters, map] = kMean.getOptimalKClusters(songsLargeClearCluster);
-            chai.expect(clusters.length).to.equal(bestK);
-            chai.expect(map.size).to.equal(10);
-        } catch (err) {
-            console.log(err);
-            chai.expect.fail("not supposed to fail");
-        }
+        const [bestK, clusters, map] = kMean.getOptimalKClusters(songsLargeClearCluster);
+        chai.expect(clusters.length).to.equal(bestK);
+        chai.expect(map.size).to.equal(10);
     });
 
 });

--- a/main/test/service/AzureFaceAPIService.spec.js
+++ b/main/test/service/AzureFaceAPIService.spec.js
@@ -16,9 +16,6 @@ describe("unit test for dataURL", function () {
             .then((res) => {
                 console.log(res);
                 chai.assert(typeof res === "object" && !Array.isArray(res));
-            }).catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -27,7 +24,6 @@ describe("unit test for dataURL", function () {
             .then(() => {
                 chai.expect.fail("supposed to fail");
             }).catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -37,7 +33,6 @@ describe("unit test for dataURL", function () {
             .then(() => {
                 chai.expect.fail("supposed to fail");
             }).catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -47,7 +42,6 @@ describe("unit test for dataURL", function () {
             .then(() => {
                 chai.expect.fail("supposed to fail");
             }).catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.AzureFaceApiError);
             });
     });
@@ -57,7 +51,6 @@ describe("unit test for dataURL", function () {
             .then(() => {
                 chai.expect.fail("supposed to fail");
             }).catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.NoUserDetectedError);
             });
     });
@@ -74,9 +67,6 @@ describe("unit test for dataURL", function () {
                 }
 
                 chai.expect(maxEmotion).to.be.equal("fear");
-            }).catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -144,16 +134,12 @@ describe("unit test for dataURL", function () {
     });
 
     it("test handleAzureFaceAPIResponse", function () {
-        try {
-            const emotion = {
-                anger: 0, contempt: 0, disgust: 0, fear: 0, happiness: 0, neutral: 0.999, sadness: 0, surprise: 0,
-            };
-            const result = azureFaceAPIService.handleAzureFaceAPIResponse({
-                data: [{faceAttributes: {emotion: emotion}}],
-            });
-            chai.expect(JSON.stringify(result)).to.be.equal(JSON.stringify(emotion));
-        } catch (e) {
-            chai.expect.fail("not supposed to fail");
-        }
+        const emotion = {
+            anger: 0, contempt: 0, disgust: 0, fear: 0, happiness: 0, neutral: 0.999, sadness: 0, surprise: 0,
+        };
+        const result = azureFaceAPIService.handleAzureFaceAPIResponse({
+            data: [{faceAttributes: {emotion: emotion}}],
+        });
+        chai.expect(JSON.stringify(result)).to.be.equal(JSON.stringify(emotion));
     });
 });

--- a/main/test/service/EmotionService.spec.js
+++ b/main/test/service/EmotionService.spec.js
@@ -27,9 +27,6 @@ describe("unit test for EmotionService", function () {
             .then((features) => {
                 console.log(features);
                 chai.assert(typeof features === "object");
-            })
-            .catch((err) => {
-                chai.expect.fail("not supposed to fail" + err);
             });
     });
 
@@ -46,9 +43,6 @@ describe("unit test for EmotionService", function () {
                     console.log(res);
                     chai.assert(typeof res === "object");
                 }
-            })
-            .catch((e) => {
-                chai.expect.fail("not supposed to fail" + e);
             });
     });
 
@@ -58,7 +52,6 @@ describe("unit test for EmotionService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -69,7 +62,6 @@ describe("unit test for EmotionService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -80,7 +72,6 @@ describe("unit test for EmotionService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -91,7 +82,6 @@ describe("unit test for EmotionService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -103,30 +93,22 @@ describe("unit test for EmotionService", function () {
                 const dominantExpression = emotionService.getDominantExpression(res);
                 chai.expect(dominantExpression).to.be.equal("neutral");
                 console.log(dominantExpression);
-            }).catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
     it("test getDominantExpressions", function () {
-        try {
-            const data = {
-                anger: 0,
-                contempt: 0,
-                disgust: 0,
-                fear: 0,
-                happiness: 0,
-                neutral: 0.999,
-                sadness: 0,
-                surprise: 0,
-            };
-            const result = emotionService.getDominantExpression(data);
-            chai.expect(result).to.be.equal("neutral");
-        } catch (e) {
-            console.log(e);
-            chai.expect.fail("not supposed to fail");
-        }
+        const data = {
+            anger: 0,
+            contempt: 0,
+            disgust: 0,
+            fear: 0,
+            happiness: 0,
+            neutral: 0.999,
+            sadness: 0,
+            surprise: 0,
+        };
+        const result = emotionService.getDominantExpression(data);
+        chai.expect(result).to.be.equal("neutral");
     });
 
     it("test getDominantExpressions - invalid input null", function () {
@@ -134,7 +116,6 @@ describe("unit test for EmotionService", function () {
             emotionService.getDominantExpression(null);
             chai.expect.fail("supposed to fail");
         } catch (e) {
-            console.log(e);
             chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
         }
     });
@@ -144,7 +125,6 @@ describe("unit test for EmotionService", function () {
             emotionService.getDominantExpression("null");
             chai.expect.fail("supposed to fail");
         } catch (e) {
-            console.log(e);
             chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
         }
     });
@@ -154,7 +134,6 @@ describe("unit test for EmotionService", function () {
             emotionService.getDominantExpression([]);
             chai.expect.fail("supposed to fail");
         } catch (e) {
-            console.log(e);
             chai.expect(e).to.be.instanceOf(Err.InvalidInputError);
         }
     });

--- a/main/test/service/RefreshCredentialService.spec.js
+++ b/main/test/service/RefreshCredentialService.spec.js
@@ -25,9 +25,6 @@ describe("test refreshing with credentials", function () {
         spotifyApi.setAccessToken(expiredAccessToken);
         return refreshCredentialService.checkCredentials().then((result) => {
             chai.assert.isFalse(result);
-        }).catch((err) => {
-            console.log(err);
-            chai.expect.fail("not supposed to fail");
         });
     });
 
@@ -38,8 +35,6 @@ describe("test refreshing with credentials", function () {
             })
             .then((result) => {
                 chai.assert.isTrue(result);
-            }).catch((err) => {
-                chai.expect.fail("not supposed to fail" + err);
             });
     });
 
@@ -60,10 +55,6 @@ describe("test refreshing with credentials", function () {
         return refreshCredentialService.tryRefreshCredential()
             .then((newAccessToken) => {
                 chai.expect(oldAccessToken).to.not.equal(newAccessToken);
-            })
-            .catch((e) => {
-                console.log("Caught error" + e);
-                chai.expect.fail("not supposed to fail");
             });
     });
 });

--- a/main/test/service/SpotifyService.spec.js
+++ b/main/test/service/SpotifyService.spec.js
@@ -50,10 +50,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 console.log("# RECENT SONGS ADDED: " + spotifyService.trackHashMap.size);
                 chai.assert(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -62,10 +58,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 console.log("# TOP SONGS ADDED: " + spotifyService.trackHashMap.size);
                 chai.assert(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
 
     });
@@ -75,10 +67,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 console.log("# TOP ARTIST SONGS ADDED: " + spotifyService.trackHashMap.size);
                 chai.assert(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
 
     });
@@ -88,10 +76,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 console.log("# SAVED SONGS ADDED: " + spotifyService.trackHashMap.size);
                 chai.assert(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
 
     });
@@ -99,12 +83,7 @@ describe("unit test for SpotifyService", function () {
     it("get all sample data audio features", function () {
         return spotifyService.getAllAudioFeatures()
             .then((res) => {
-                // console.log(res);
                 chai.expect(Object.keys(res).length).to.be.equal(spotifyService.trackHashMap.size);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
 
     });
@@ -117,10 +96,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 chai.assert(res);
                 console.log("# RECENT SONGS ADDED: " + spotifyService.trackHashMap.size);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     }
 
@@ -161,10 +136,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 console.log("# RECENT SONGS ADDED: " + spotifyService.trackHashMap.size);
                 chai.assert(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -173,10 +144,6 @@ describe("unit test for SpotifyService", function () {
             .then((res) => {
                 console.log("# PLAYLIST SONGS ADDED: " + spotifyService.trackHashMap.size);
                 chai.assert(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -188,10 +155,6 @@ describe("unit test for SpotifyService", function () {
                 chai.expect(res.images).to.not.be.undefined;
                 chai.expect(res.external_urls).to.not.be.undefined;
                 console.log(res);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -203,10 +166,6 @@ describe("unit test for SpotifyService", function () {
                 chai.assert.isNotNull(result.body);
                 chai.expect(result.body.name).to.be.equal("Flow Playlist: " + spotifyService.mood);
                 chai.assert.isFalse(result.body.public);
-            })
-            .catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -217,7 +176,6 @@ describe("unit test for SpotifyService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidResponseError);
             });
     });
@@ -230,9 +188,6 @@ describe("unit test for SpotifyService", function () {
             .then((url) => {
                 chai.assert.isNotNull(url);
                 chai.expect(typeof url).to.be.equal("string");
-            }).catch((err) => {
-                console.log(err);
-                chai.expect.fail("not supposed to fail");
             });
     });
 
@@ -242,7 +197,6 @@ describe("unit test for SpotifyService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -253,7 +207,6 @@ describe("unit test for SpotifyService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });
@@ -264,7 +217,6 @@ describe("unit test for SpotifyService", function () {
                 chai.expect.fail("supposed to fail");
             })
             .catch((err) => {
-                console.log(err);
                 chai.expect(err).to.be.instanceOf(Err.InvalidInputError);
             });
     });


### PR DESCRIPTION
## Motivation:

In continuous integration, it's hard to tell if a test is failing if we keep logging the errors that we expect to be thrown. I've removed logging for the errors thrown to make it easier to understand CI output. 

Also, we no longer need the places where we say `chai.expect.fail("not supposed to fail")`. Instead, we should let the errors be thrown and let the testing framework handle/log the errors 